### PR TITLE
Support context menu (long press) events

### DIFF
--- a/otpview/src/main/java/com/mukesh/OtpView.java
+++ b/otpview/src/main/java/com/mukesh/OtpView.java
@@ -139,7 +139,6 @@ public class OtpView extends AppCompatEditText {
     setMaxLength(otpViewItemCount);
     paint.setStrokeWidth(lineWidth);
     setupAnimator();
-    super.setCursorVisible(false);
     setTextIsSelectable(false);
   }
 


### PR DESCRIPTION
## Proposed changes

Since this subclass of `AppCompatEditText` initializes with the cursor not visible, it is not possible to support pasting into this edit text without a default value.  This change allows for that functionality by removing the programmatic disabling of the cursor visibility when the view is inflated.  As the library was, even setting this `setCursorVisible(true)` after this view was inflated and attached, the cursor would not show and the user not be able to long press and show the context menu.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
